### PR TITLE
Add Dockerfile to build the font within a clean, reproducible Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+add_emoji_gsub.pyc
+build
+waveflag
+
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:buster
+RUN apt update && apt install -y \
+    git \
+    zopfli \
+    libcairo2-dev
+
+# Install nototools
+RUN git clone https://github.com/googlefonts/nototools.git /nototools
+WORKDIR /nototools
+RUN pip install -r requirements.txt
+RUN pip install -e .
+
+ADD . /blobmoji
+WORKDIR /blobmoji
+
+# Build blobmoji font
+CMD make -j $(nproc)

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,11 @@ WORKDIR /nototools
 RUN pip install -r requirements.txt
 RUN pip install -e .
 
+# Create output dir
+RUN mkdir /output
+
 ADD . /blobmoji
 WORKDIR /blobmoji
 
 # Build blobmoji font
-CMD make -j $(nproc)
+CMD make -j $(nproc) && cp NotoColorEmoji.ttf /output/

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ especially if you are using zopflipng for compression.  Intermediate products
 (compressed image files, for example) will be put into a build subdirectory; the
 font will be at the top level.
 
+## Docker build
+
+Alternatively, you can also build the font within Docker through the provided Dockerfile.
+Just run `docker build . -t blobmoji && docker run --rm -it -v "$PWD/output:/output" blobmoji`. The resulting font will reside in the 'output' folder in your current working directory.
+
 ## Using NotoColorEmoji
 
 NotoColorEmoji uses the CBDT/CBLC color font format, which is supported by Android


### PR DESCRIPTION
The container is based on a Python Debian image, installs all dependencies, and builds the font on execution. The result is copied to the host computer through a Docker volume.
This PR adds the Dockerfile, as well as documentation on how to use it.