### PR TITLE
Fix Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,8 @@
+Dockerfile
+.dockerignore
 add_emoji_gsub.pyc
 build
 waveflag
 
 .git/
+fonts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:buster
+FROM python:3.7
 RUN apt update && apt install -y \
     git \
     zopfli \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,22 @@
-FROM python:3.7
-RUN apt update && apt install -y \
+FROM python:3.7-slim
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
     git \
     zopfli \
-    libcairo2-dev
+    libcairo2-dev \
+    make \
+    imagemagick \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install nototools
 RUN git clone https://github.com/googlefonts/nototools.git /nototools
 WORKDIR /nototools
-RUN pip install -r requirements.txt
-RUN pip install -e .
-
-# Create output dir
-RUN mkdir /output
+RUN pip install --no-cache -r requirements.txt && pip install --no-cache -e .
 
 ADD . /blobmoji
 WORKDIR /blobmoji
 
-# Build blobmoji font
+RUN mkdir /output
+
 CMD make -j $(nproc) && cp NotoColorEmoji.ttf /output/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM python:3.7-slim
+FROM python:slim
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-    git \
-    zopfli \
-    libcairo2-dev \
     make \
+    gcc \
+    zopfli \
+    libc-dev \
+    libpng-dev \
+    libcairo2-dev \
     imagemagick \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/googlefonts/nototools.git /nototools
-WORKDIR /nototools
-RUN pip install --no-cache -r requirements.txt && pip install --no-cache -e .
+RUN pip install --no-cache notofonttools
 
 ADD . /blobmoji
 WORKDIR /blobmoji


### PR DESCRIPTION
Python after 3.7 removes `tp_print` from `PyTypeObject`, preventing `pyclipper` 1.1.0.post1 from compiling.